### PR TITLE
Impove automations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@Erikmitk

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/Build" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/Build"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
This PR bumps the versions of the used GH Actions and switches dependabot updates to monthly with grouping everything together. This means dependabot will not open a PR for every single dependency, but will open only one PR for all dependencies at once.

